### PR TITLE
Sweetalert2 Theme Updated Based on the Website Overall Theme

### DIFF
--- a/404.html
+++ b/404.html
@@ -23,6 +23,7 @@
   <meta name="apple-mobile-web-app-title" content="GitHubP">
   <meta name="theme-color" content="#ffffff">
   <link rel="stylesheet" href="libs/sweetalert2/sweetalert2.min.css">
+  <link href="style.css" rel="stylesheet" type="text/css">
 </head>
 <body>
 <script src="libs/sweetalert2/sweetalert2.min.js"></script>

--- a/script.js
+++ b/script.js
@@ -22,6 +22,23 @@ const CONFIG = {
   }
 }
 
+function showAlert(options) {
+  return Swal.fire({
+    buttonsStyling: false,
+    customClass: {
+      container: "githubp-swal-container",
+      popup: "githubp-swal",
+      icon: "githubp-swal-icon",
+      title: "githubp-swal-title",
+      htmlContainer: "githubp-swal-text",
+      actions: "githubp-swal-actions",
+      confirmButton: "githubp-swal-button githubp-swal-button-confirm",
+      cancelButton: "githubp-swal-button githubp-swal-button-cancel"
+    },
+    ...options
+  });
+}
+
 function showError(message) {
   return showAlert({
     icon: "error",

--- a/script.js
+++ b/script.js
@@ -23,8 +23,9 @@ const CONFIG = {
 }
 
 function showError(message) {
-  return Swal.fire({
+  return showAlert({
     icon: "error",
+    iconColor: "#d73a49",
     title: "Error",
     text: message,
     confirmButtonText: "OK"
@@ -32,8 +33,9 @@ function showError(message) {
 }
 
 function showConfirm(message) {
-  return Swal.fire({
-    icon: "warning",
+  return showAlert({
+    icon: "question",
+    iconColor: "#62B039",
     title: "Confirm",
     text: message,
     showCancelButton: true,

--- a/style.css
+++ b/style.css
@@ -8,7 +8,7 @@ html {
     --githubp-border: #ddd;
     --githubp-border-soft: #eee;
     --githubp-soft: #f6f8fa;
-    --githubp-focus: rgba(98, 176, 57, 0.25);
+    --githubp-focus: rgb(98 176 57 / 25%);
 }
 
 body {
@@ -153,7 +153,7 @@ footer {
 }
 
 .githubp-swal-container.swal2-backdrop-show {
-    background: rgba(0, 0, 0, 0.28);
+    background: rgb(0 0 0 / 28%);
 }
 
 .swal2-popup.githubp-swal {
@@ -162,7 +162,7 @@ footer {
     border: 1px solid var(--githubp-border);
     border-radius: 0.5rem;
     background: #fff;
-    box-shadow: 0 20px 48px rgba(0, 0, 0, 0.16);
+    box-shadow: 0 20px 48px rgb(0 0 0 / 16%);
     color: var(--githubp-text);
     font-family: system-ui, sans-serif;
 }
@@ -250,7 +250,7 @@ footer {
     color: var(--githubp-text);
 }
 
-@media (max-width: 420px) {
+@media (width <= 420px) {
     .swal2-popup.githubp-swal {
         padding: 1.2rem 1rem 1rem;
     }

--- a/style.css
+++ b/style.css
@@ -1,3 +1,16 @@
+html {
+    --githubp-accent: #62B039;
+    --githubp-accent-strong: #3f7d25;
+    --githubp-accent-strong-hover: #356b20;
+    --githubp-danger: #d73a49;
+    --githubp-text: #000;
+    --githubp-muted: #444;
+    --githubp-border: #ddd;
+    --githubp-border-soft: #eee;
+    --githubp-soft: #f6f8fa;
+    --githubp-focus: rgba(98, 176, 57, 0.25);
+}
+
 body {
     font-family: system-ui, sans-serif;
     margin: 0;

--- a/style.css
+++ b/style.css
@@ -34,7 +34,7 @@ h1 {
 }
 
 p {
-    color: #444;
+    color: var(--githubp-muted);
     line-height: 1.5;
     margin-bottom: 1rem;
 }
@@ -45,7 +45,7 @@ p {
 
 .example {
     font-family: monospace;
-    background: #f6f8fa;
+    background: var(--githubp-soft);
     padding: 0.6rem;
     border-radius: 6px;
     font-size: 0.9rem;
@@ -65,7 +65,7 @@ p {
 }
 
 #recent-header {
-    color: #000;
+    color: var(--githubp-text);
     font-size: 1rem;
     margin-bottom: 0.5rem;
     font-weight: bolder;
@@ -76,14 +76,14 @@ p {
     padding: 0;
     margin: 0;
     background: #fff;
-    border: 1px solid #ddd;
+    border: 1px solid var(--githubp-border);
     border-radius: 0.5rem;
     overflow: hidden;
 }
 
 #recent-list li {
     padding: 0.5rem 0.75rem;
-    border-bottom: 1px solid #eee;
+    border-bottom: 1px solid var(--githubp-border-soft);
     font-size: 0.8rem;
     display: flex;
     justify-content: space-between;
@@ -124,7 +124,7 @@ p {
 }
 
 .green {
-    color: #62B039;
+    color: var(--githubp-accent);
 }
 
 input {
@@ -150,4 +150,112 @@ footer {
 .icon {
   width: 1.1rem;
   pointer-events: none;
+}
+
+.githubp-swal-container.swal2-backdrop-show {
+    background: rgba(0, 0, 0, 0.28);
+}
+
+.swal2-popup.githubp-swal {
+    width: min(100%, 24rem);
+    padding: 1.35rem 1.35rem 1.1rem;
+    border: 1px solid var(--githubp-border);
+    border-radius: 0.5rem;
+    background: #fff;
+    box-shadow: 0 20px 48px rgba(0, 0, 0, 0.16);
+    color: var(--githubp-text);
+    font-family: system-ui, sans-serif;
+}
+
+.githubp-swal-icon.swal2-icon {
+    margin: 0 auto 0.85rem;
+    transform: scale(0.82);
+}
+
+.githubp-swal-icon.swal2-error {
+    border-color: var(--githubp-danger);
+    color: var(--githubp-danger);
+}
+
+.githubp-swal-icon.swal2-error [class^="swal2-x-mark-line"] {
+    background-color: var(--githubp-danger);
+}
+
+.githubp-swal-icon.swal2-question {
+    border-color: var(--githubp-accent);
+    color: var(--githubp-accent);
+}
+
+.githubp-swal-title.swal2-title {
+    padding: 0;
+    color: var(--githubp-text);
+    font-size: 1.35rem;
+    font-weight: 700;
+    line-height: 1.25;
+}
+
+.githubp-swal-text.swal2-html-container {
+    margin: 0.5rem 0 0;
+    padding: 0;
+    color: var(--githubp-muted);
+    font-size: 1rem;
+    line-height: 1.5;
+}
+
+.githubp-swal-actions.swal2-actions {
+    width: 100%;
+    margin: 1.25rem 0 0;
+    gap: 0.5rem;
+}
+
+.githubp-swal-button {
+    display: inline-flex;
+    min-width: 5.75rem;
+    align-items: center;
+    justify-content: center;
+    margin: 0;
+    padding: 0.7rem 1rem;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.githubp-swal-button:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px var(--githubp-focus);
+}
+
+.githubp-swal-button-confirm {
+    border-color: var(--githubp-accent-strong);
+    background: var(--githubp-accent-strong);
+    color: #fff;
+}
+
+.githubp-swal-button-confirm:hover {
+    border-color: var(--githubp-accent-strong-hover);
+    background: var(--githubp-accent-strong-hover);
+}
+
+.githubp-swal-button-cancel {
+    border-color: var(--githubp-border);
+    background: #fff;
+    color: var(--githubp-muted);
+}
+
+.githubp-swal-button-cancel:hover {
+    background: var(--githubp-soft);
+    color: var(--githubp-text);
+}
+
+@media (max-width: 420px) {
+    .swal2-popup.githubp-swal {
+        padding: 1.2rem 1rem 1rem;
+    }
+
+    .githubp-swal-button {
+        flex: 1;
+    }
 }


### PR DESCRIPTION
#### Reference Issues/PRs
#32 
#### What does this implement/fix? Explain your changes
The overall feeling and style tone of the alert messages provided by Sweetalert2 has been updated to reflect the webpage's style. You can see examples of before vs. after in below. The changes are mostly visible for confirm alert where both icon and color of the icon has been updated.

## Before

<img width="49%" alt="Screenshot from 2026-05-21 23-26-49" src="https://github.com/user-attachments/assets/98527b90-921b-4577-8a2e-38b42562d261" />
<img width="49%" alt="Screenshot from 2026-05-21 23-27-36" src="https://github.com/user-attachments/assets/56c1dff8-f3e3-4918-92b3-205974290391" />

## After

<img width="49%" alt="Screenshot from 2026-05-21 23-29-29" src="https://github.com/user-attachments/assets/eb98f216-1633-43a5-b91d-b403922158bc" />
<img width="49%" alt="Screenshot from 2026-05-21 23-29-47" src="https://github.com/user-attachments/assets/4f92e0e2-3597-45c5-8679-762dcd8112f7" />

#### Any other comments?
For this PR I used Codex mainly to capture the main style tone and apply it to the alert messages.